### PR TITLE
Add support for Sudo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Each specified recipe is parsed and the primitives inside them are then executed
 * `Set name "value"`
   * Set the variable "name" to have the value "value".
   * Once set a variable can be used in the recipe, or as part of template-expansion.
+* `Sudo` may be added as a prefix to `Run` and `IfChanged`.
+  * If present this will ensure the specified command runs as `root`.
+  * The sudo example found beneath [examples/sudo/](examples/sudo/) demonstrates usage.
 
 **NOTE**: Previously the "Run" and "IfChanged" primitives took bare arguments, now they __must__ be quoted.  For example:
 

--- a/examples/sudo/deploy.recipe
+++ b/examples/sudo/deploy.recipe
@@ -1,0 +1,35 @@
+#
+# This is a simple recipe which demonstrates the usage of "sudo".
+#
+# Launch it like so:
+#
+#   $ deployr -target user@host.example.com:22 ./deploy.recipe
+#
+# Sample output:
+#
+#   $ deployr run -target steve@host.example.com deploy.recipe
+#   Please enter your password for sudo: s4cr3t
+#
+#   This command runs as "steve"
+#   uid=1000(steve) gid=100(users) groups=100(users),1007(steve),1034(ssh_users)
+#
+#   This command runs as "root"
+#   uid=0(root) gid=0(root) groups=0(root),1034(ssh_users)
+#
+#
+
+
+
+#
+# "Run" executes a command as the user we connect with.
+#
+Run "echo 'This command runs as \"${user}\"'"
+Run "/usr/bin/id"
+
+
+
+#
+# "Sudo Run" runs a command as root.
+#
+Run "echo 'This command runs as \"root\"'"
+Sudo Run "/usr/bin/id"

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -46,6 +46,11 @@ func (p *Parser) Parse() ([]statement.Statement, error) {
 	var result []statement.Statement
 
 	//
+	// Does the next command use Sudo?
+	//
+	sudo := false
+
+	//
 	// We have a lexer, so we process each token in-turn until we
 	// hit the end-of-file.
 	//
@@ -225,6 +230,13 @@ func (p *Parser) Parse() ([]statement.Statement, error) {
 			//
 			s := statement.Statement{Token: tok}
 			s.Arguments = args
+
+			//
+			// Perserve the SUDO state
+			//
+			s.Sudo = sudo
+			sudo = false
+
 			result = append(result, s)
 			break
 
@@ -256,6 +268,13 @@ func (p *Parser) Parse() ([]statement.Statement, error) {
 			//
 			s := statement.Statement{Token: tok}
 			s.Arguments = args
+
+			//
+			// Perserve the SUDO state
+			//
+			s.Sudo = sudo
+			sudo = false
+
 			result = append(result, s)
 			break
 
@@ -290,6 +309,10 @@ func (p *Parser) Parse() ([]statement.Statement, error) {
 			s := statement.Statement{Token: tok}
 			s.Arguments = args
 			result = append(result, s)
+			break
+
+		case "Sudo":
+			sudo = true
 			break
 
 		case "EOF":

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -451,7 +451,7 @@ func TestSet(t *testing.T) {
 	}
 }
 
-// TestSudo tests that we have sudo-handing correct.
+// TestSudoHandling tests that we have sudo-handing correct.
 func TestSudoHandling(t *testing.T) {
 
 	//
@@ -477,5 +477,79 @@ func TestSudoHandling(t *testing.T) {
 	}
 	if len(program) != 0 {
 		t.Fatalf("Unexpected length, wanted 0 got %d\n", len(program))
+	}
+}
+
+// TestSudoFlag tests that we actually set the flag for a sudo-using
+// command.
+func TestSudoFlag(t *testing.T) {
+
+	//
+	// The stream of tokens we'll expecting a sudo-flag to be set.
+	//
+	set := []token.Token{
+		{Type: "Sudo", Literal: "Sudo"},
+		{Type: "Run", Literal: "Run"},
+		{Type: "STRING", Literal: "/bin/ls"},
+		{Type: "EOF", Literal: "EOF"},
+	}
+
+	//
+	// The stream of tokens we'll parse expecting no sudo-flag to be
+	// set.
+	//
+	unset := []token.Token{
+		{Type: "Run", Literal: "Run"},
+		{Type: "STRING", Literal: "/bin/ls"},
+		{Type: "EOF", Literal: "EOF"},
+	}
+
+	//
+	// Now parse into statements.
+	//
+	fl := NewFakeLexer(set)
+	p := New(fl)
+	program, err := p.Parse()
+
+	//
+	// We expect one statement, with zero errors.
+	//
+	if err != nil {
+		t.Fatalf("Received an unexpected error!")
+	}
+	if len(program) != 1 {
+		t.Fatalf("Unexpected length, wanted 1 got %d\n", len(program))
+	}
+
+	//
+	// The statement will use sudo
+	//
+
+	if program[0].Sudo != true {
+		t.Fatalf("We expected our Run command to use sudo %v", program[0])
+	}
+
+	//
+	// Now parse into statements.
+	//
+	fl = NewFakeLexer(unset)
+	p = New(fl)
+	program, err = p.Parse()
+
+	//
+	// We expect one statement, with zero errors.
+	//
+	if err != nil {
+		t.Fatalf("Received an unexpected error!")
+	}
+	if len(program) != 1 {
+		t.Fatalf("Unexpected length, wanted 1 got %d\n", len(program))
+	}
+
+	//
+	// The statement will not use sudo
+	//
+	if program[0].Sudo != false {
+		t.Fatalf("We didn't expect our Run command to use sudo %v", program[0])
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -264,7 +264,7 @@ func TestBareString(t *testing.T) {
 	program, err := p.Parse()
 
 	//
-	// We expect one statement, with zero errors.
+	// We expect to receive an error & empty-program
 	//
 	if err == nil {
 		t.Fatalf("We expected an error, but saw none!")
@@ -281,7 +281,7 @@ func TestBareIdentifier(t *testing.T) {
 	// The stream of tokens we'll parse.
 	//
 	toks := []token.Token{
-		{Type: "IDENTIFIER", Literal: "/bin/ls"},
+		{Type: "IDENT", Literal: "/bin/ls"},
 		{Type: "EOF", Literal: "EOF"},
 	}
 
@@ -293,7 +293,7 @@ func TestBareIdentifier(t *testing.T) {
 	program, err := p.Parse()
 
 	//
-	// We expect one statement, with zero errors.
+	// We expect to receive an error & empty-program
 	//
 	if err == nil {
 		t.Fatalf("We expected an error, but saw none!")
@@ -448,5 +448,34 @@ func TestSet(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "as argument 2") {
 		t.Fatalf("Our error was misleading: %s", err.Error())
+	}
+}
+
+// TestSudo tests that we have sudo-handing correct.
+func TestSudoHandling(t *testing.T) {
+
+	//
+	// The stream of tokens we'll parse.
+	//
+	toks := []token.Token{
+		{Type: "Sudo", Literal: "Sudo"},
+		{Type: "EOF", Literal: "EOF"},
+	}
+
+	//
+	// Now parse into statements.
+	//
+	fl := NewFakeLexer(toks)
+	p := New(fl)
+	program, err := p.Parse()
+
+	//
+	// We expect one statement, with zero errors.
+	//
+	if err != nil {
+		t.Fatalf("Received an unexpected error!")
+	}
+	if len(program) != 0 {
+		t.Fatalf("Unexpected length, wanted 0 got %d\n", len(program))
 	}
 }

--- a/statement/statement.go
+++ b/statement/statement.go
@@ -20,6 +20,10 @@ type Statement struct {
 	// Token is the main action "Set", "Run", etc.
 	Token token.Token
 
+	// When running a command `Run`, `IfChanged` should we use
+	// sudo?
+	Sudo bool
+
 	// Arguments contains the arguments to the operation.
 	Arguments []token.Token
 }

--- a/token/token.go
+++ b/token/token.go
@@ -23,6 +23,7 @@ const (
 	IF_CHANGED    = "IfChanged"
 	RUN           = "Run"
 	SET           = "Set"
+	SUDO          = "Sudo"
 )
 
 // keywords holds our reversed keywords
@@ -33,6 +34,7 @@ var keywords = map[string]TokenType{
 	"IfChanged":    IF_CHANGED,
 	"Run":          RUN,
 	"Set":          SET,
+	"Sudo":         SUDO,
 }
 
 // LookupIdentifier used to determinate whether identifier is keyword nor not


### PR DESCRIPTION
This pull-request is work-in-progress, but currently allows the use of the `Sudo` token to mark a following statement as requiring the use of `sudo`.

For example this is a normal script:

       DeployTo user@host.example.com
       Run "/usr/bin/id"

Expected output will be "user ..".

This would require the use of Sudo:

       DeployTo user@host.example.com
       Sudo Run "/usr/bin/id"

Expected output will be "root .."

This will close #8, when merged.
