### PR TITLE
Use ssh-agent if SSH_AUTH_SOCKET is set and points to a socket.

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -142,7 +142,11 @@ func (e *Evaluator) ConnectTo(target string) error {
 	//
 	// Finally connect.
 	//
-	e.Connection, err = simplessh.ConnectWithKeyFile(destination, user, e.Identity)
+	if util.HasSshAgent() {
+		e.Connection, err = simplessh.ConnectWithAgent(destination, user)
+	} else {
+		e.Connection, err = simplessh.ConnectWithKeyFile(destination, user, e.Identity)
+	}
 	if err != nil {
 		return err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -39,3 +39,20 @@ func HashFile(filePath string) (string, error) {
 
 	return returnSHA1String, nil
 }
+
+// HasSshAgent reports whether the SSH agent is available
+func HasSshAgent() bool {
+	authsock, ok := os.LookupEnv("SSH_AUTH_SOCK")
+	if !ok {
+		return false
+	}
+	if dirent, err := os.Stat(authsock); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		if dirent.Mode() & os.ModeSocket == 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Hi Steve, I need to use the ssh-agent for authentication. So I patched your code. The patch reads the SSH_AUTH_SOCKET and checks if it points to a socket. If that's the case it will authenticate agains the ssh-agent.