### PR TITLE
fix typo in env var SSH_AUTH_SOCK

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ By default `~/.ssh/id_rsa` will be used as the key to connect with, but if you p
 
     $ deployr run -identity ~/.ssh/host
 
-In addition to using a key specified via the command-line deployr also supports the use of `ssh-agent`.  Simply set the environmental-variable `SSH_AUTH_SOCKET` to the path of your agent's socket.
+In addition to using a key specified via the command-line deployr also supports the use of `ssh-agent`.  Simply set the environmental-variable `SSH_AUTH_SOCK` to the path of your agent's socket.
 
 
 


### PR DESCRIPTION
Hello Steve,

I spotted this little typo.
I love the simplicity of this DOCKERFILE-like format. Thank you!