### PR TITLE
Check for pageant on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ By default `~/.ssh/id_rsa` will be used as the key to connect with, but if you p
     $ deployr run -identity ~/.ssh/host
 
 In addition to using a key specified via the command-line deployr also supports the use of `ssh-agent`.  Simply set the environmental-variable `SSH_AUTH_SOCK` to the path of your agent's socket.
+On Windows deployr supports `pageant`, which is a Windows-specific implementation of SSH Agent. If pageant is running, deployr will detect it and use it for authentication.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/skx/deployr
 go 1.12
 
 require (
+	github.com/davidmz/go-pageant v1.0.2
 	github.com/google/subcommands v1.2.0
 	github.com/pkg/sftp v1.13.6 // indirect
 	github.com/sfreiberg/simplessh v0.0.0-20220719182921-185eafd40485

--- a/util/util.go
+++ b/util/util.go
@@ -43,6 +43,10 @@ func HashFile(filePath string) (string, error) {
 
 // HasSSHAgent reports whether the SSH agent is available
 func HasSSHAgent() bool {
+	if isPageantAvailable() {
+		return true
+	}
+
 	authsock, ok := os.LookupEnv("SSH_AUTH_SOCK")
 	if !ok {
 		return false

--- a/util/util_unix.go
+++ b/util/util_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package util
+
+func isPageantAvailable() bool {
+	return false
+}

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+// +build windows
+
+package util
+
+import "github.com/davidmz/go-pageant"
+
+func isPageantAvailable() bool {
+	return pageant.Available()
+}


### PR DESCRIPTION
The `simplessh` package uses pageant for its SSH agent on Windows. Update the `util.HashSSHAgent` function to detect pageant if running on Windows. Note that the package `github.com/davidmz/go-pageant` is now a direct dependency, and the version used is the same version required by the `simplessh` package.

Fixes #24